### PR TITLE
FIx Russian region

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
         #links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-af.srs"]="country/geosite-af.srs"
         links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-ir.srs"]="country/geosite-ir.srs"
         links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-cn.srs"]="country/geosite-cn.srs"
-        links["https://github.com/savely-krasovsky/antizapret-sing-box/releases/latest/download/antizapret.srs"]="country/geosite-ru.srs"
-        #links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-category-gov-ru.srs"]="country/geosite-ru.srs"
+        #links["https://github.com/savely-krasovsky/antizapret-sing-box/releases/latest/download/antizapret.srs"]="country/geosite-ru-blocked.srs"
+        links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-category-ru.srs"]="country/geosite-ru.srs"
         links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-category-gov-ru.srs?"]="country/geosite-id.srs"
         links["https://raw.githubusercontent.com/Chocolate4U/Iran-sing-box-rules/rule-set/geosite-category-gov-ru.srs??"]="country/geosite-tr.srs"
         


### PR DESCRIPTION
1. File https://github.com/savely-krasovsky/antizapret-sing-box/releases/latest/download/antizapret.srs contains sites that Blocked in Russia. So using this rule-set as "direct" actually ruins everything.   
This file can be used as 2nd Russia region, for example "Russia - Proxy only blocked sites". SO this rule-set can be used as for proxy connection, and everything else goes direct.
3. geosite-category-ru.srs This file was decompiled and confirmed be the best currently existed, it contains all common prefixes and VK and yandex categories.